### PR TITLE
changed ingestion procedure to allow for writing raw text + metadata to json file, per document

### DIFF
--- a/graph/ingestion.py
+++ b/graph/ingestion.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from datetime import datetime, timezone
 import json
 import mimetypes
 import uuid
@@ -193,6 +194,30 @@ def _write_extraction_audits(
     ensure_project_dirs(project_paths)
     target = project_paths.extraction_audits_dir / f"{Path(filename).stem}.audit.json"
     target.write_text(json.dumps(audits, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _write_raw_text_audit(
+    project_paths: Optional[ProjectPaths],
+    *,
+    filename: str,
+    doc_meta: Dict[str, Any],
+    raw_text: str,
+) -> None:
+    if project_paths is None:
+        return
+    ensure_project_dirs(project_paths)
+    payload = {
+        "filename": filename,
+        "filepath": doc_meta.get("filepath"),
+        "doc_id": doc_meta.get("doc_id"),
+        "content_hash": doc_meta.get("content_hash"),
+        "language": doc_meta.get("language", "unknown"),
+        "char_count": len(raw_text),
+        "extracted_at": datetime.now(timezone.utc).isoformat(),
+        "raw_text": raw_text,
+    }
+    target = project_paths.extraction_audits_dir / f"{Path(filename).stem}.raw.json"
+    target.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
 def _write_retrieval_graph_snapshot(
@@ -836,6 +861,13 @@ def ingest_paths(
             "content_hash": content_hash,                
             "full_char_count": len(full_text),
         }
+
+        _write_raw_text_audit(
+            project_paths=active_project_paths,
+            filename=p.name,
+            doc_meta=doc_meta,
+            raw_text=full_text,
+        )
 
         report(f"{step_prefix} - storing document")
         storage.add_document(doc_meta, full_text)  # from storage.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ humanfriendly==10.0
 idna==3.11
 importlib_metadata==8.7.0
 importlib_resources==6.5.2
+iniconfig==2.3.0
 ipython==9.7.0
 ipython_pygments_lexers==1.1.1
 jedi==0.19.2
@@ -98,6 +99,7 @@ pandas==2.3.3
 parso==0.8.5
 pillow==11.3.0
 pip==25.2
+pluggy==1.6.0
 posthog==5.4.0
 prompt_toolkit==3.0.52
 propcache==0.4.1
@@ -116,6 +118,7 @@ pyparsing==3.2.5
 PyPika==0.48.9
 pyproject_hooks==1.2.0
 pyreadline3==3.5.4
+pytest==9.0.3
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 python-multipart==0.0.20

--- a/test/test_ingestion_utils.py
+++ b/test/test_ingestion_utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import json
 from collections import Counter
 from pathlib import Path
 
@@ -23,7 +24,8 @@ sys.modules.setdefault("langdetect", langdetect_stub)
 
 sys.path.append(str(Path(__file__).resolve().parent.parent / "graph"))
 
-from ingestion import _resolve_type, dedupe_entities_for_vectors
+from ingestion import _resolve_type, _write_raw_text_audit, dedupe_entities_for_vectors
+from project_paths import resolve_project_paths
 
 
 def test_resolve_type_prefers_non_unknown():
@@ -58,3 +60,36 @@ def test_dedupe_entities_prefers_typed_over_unknown():
     names_to_types = {e["name"]: e.get("type") for e in deduped}
     assert names_to_types["Alice"] == "Person"
     assert names_to_types["Bob"] == "Company"
+
+
+def test_write_raw_text_audit_writes_json_payload(tmp_path):
+    documents_root = tmp_path / "docs"
+    documents_root.mkdir()
+    project_paths = resolve_project_paths(documents_root)
+
+    doc_meta = {
+        "doc_id": "doc-123",
+        "filepath": str((documents_root / "example.txt").resolve()),
+        "content_hash": "abc123",
+        "language": "en",
+    }
+
+    _write_raw_text_audit(
+        project_paths,
+        filename="example.txt",
+        doc_meta=doc_meta,
+        raw_text="",
+    )
+
+    target = project_paths.extraction_audits_dir / "example.raw.json"
+    assert target.exists()
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["filename"] == "example.txt"
+    assert payload["doc_id"] == "doc-123"
+    assert payload["filepath"] == doc_meta["filepath"]
+    assert payload["content_hash"] == "abc123"
+    assert payload["language"] == "en"
+    assert payload["char_count"] == 0
+    assert payload["raw_text"] == ""
+    assert payload["extracted_at"].endswith("+00:00")


### PR DESCRIPTION
executed plan by GPT-5.3-Codex:

Changes made:

Added raw text audit writer in [ingestion.py:199]
Wired it into ingestion right after raw full-text assembly and document metadata creation in [ingestion.py:865]
Added UTC timestamp support import in [ingestion.py:2]
Added regression test coverage in [test_ingestion_utils.py:65]

What the new raw audit writes:
Location: .appl-kgraph/audits/extraction via existing project paths.
Filename pattern: {document_stem}.raw.json.
Payload fields: filename, filepath, doc_id, content_hash, language, char_count, extracted_at, raw_text.
Empty extracted text is still logged with char_count = 0.

Validation run:
Installed pytest in the project venv (it was missing).
Ran: python -m pytest [test_ingestion_utils.py] -q.
Result: 5 passed.