### PR TITLE
conditional triggering of writing extracted raw texts to file

### DIFF
--- a/graph/ingestion.py
+++ b/graph/ingestion.py
@@ -862,12 +862,13 @@ def ingest_paths(
             "full_char_count": len(full_text),
         }
 
-        _write_raw_text_audit(
-            project_paths=active_project_paths,
-            filename=p.name,
-            doc_meta=doc_meta,
-            raw_text=full_text,
-        )
+        if settings.extraction.raw_text_extraction_audit_enabled:
+            _write_raw_text_audit(
+                project_paths=active_project_paths,
+                filename=p.name,
+                doc_meta=doc_meta,
+                raw_text=full_text,
+            )
 
         report(f"{step_prefix} - storing document")
         storage.add_document(doc_meta, full_text)  # from storage.py

--- a/graph/settings.py
+++ b/graph/settings.py
@@ -96,6 +96,7 @@ class ExtractionSettings:
     use_chunk_language: bool = True
     detect_chunk_language: bool = False
     audit_second_pass_enabled: bool = False
+    raw_text_extraction_audit_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -281,6 +282,7 @@ def load_settings() -> Settings:
             "EXTRACTION_AUDIT_SECOND_PASS_ENABLED",
             False,
         ),
+        raw_text_extraction_audit_enabled=ut.env_bool("RAW_TEXT_EXTRACTION_AUDIT_ENABLED", False),
     )
 
     logging_settings = LoggingSettings(


### PR DESCRIPTION
These changes should enable triggering the audit of text extraction on demand.
NB: this goes together with the content of the .env file
To enable writing of the raw text (and some metadata) to file, add the following line to the .env file
<img width="802" height="130" alt="image" src="https://github.com/user-attachments/assets/b6197e9c-f030-492a-ae9b-60f2d1f9c557" />

Tested:
- line is absent in .env file -> no files are written to /appl.kgraph/audits/extraction
- line is available in .env file and RAW_TEXT_EXTRACTION_ENABLED is set to False -> no files are written to /appl.kgraph/audits/extraction
- line is available in .env file and RAW_TEXT_EXTRACTION_ENABLED is set to True -> raw texts of ingested files are written to /appl.kgraph/audits/extraction